### PR TITLE
Tidy activate and ci

### DIFF
--- a/.github/workflows/test-repos.yml
+++ b/.github/workflows/test-repos.yml
@@ -45,5 +45,5 @@ jobs:
     - name: Check devtoolset-3 with vault
       run: |
         yum install -y centos-release-scl
-        curl -sSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/activate.sh | SCL_TAR_SHA=${{ github.sha}} bash
+        curl -sSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/activate.sh | SCL_TAR_SHA=${{ github.sha}} bash -x
         yum info --skip-broken devtoolset-3

--- a/.github/workflows/test-repos.yml
+++ b/.github/workflows/test-repos.yml
@@ -8,14 +8,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
 
     - name: Check regenerated are the same
       run: |
         bash template-to-repos.sh
         git diff --quiet *.repo
 
-  centos-installs:
+  test-centos-install:
     name: Test CentOS 7 installs
     runs-on: ubuntu-latest
     container: centos:${{ matrix.centos-version }}
@@ -37,13 +37,13 @@ jobs:
         cat /etc/centos-release
         echo "CENTOS_RELEASE=${CENTOS_RELEASE:-$(grep -oP '[\d\.]+' /etc/centos-release)}"
 
-    - name: Fail install devtoolset-3 without vault
+    - name: Fail check for devtoolset-3 without vault
       run: |
         yum install -y centos-release-scl
-        yum install -y devtoolset-3 && exit 1 || exit 0
+        yum info devtoolset-3 && exit 1 || exit 0
 
-    - name: Install devtoolset-3 with vault
+    - name: Check devtoolset-3 with vault
       run: |
         yum install -y centos-release-scl
         curl -sSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/activate.sh | SCL_TAR_SHA=${{ github.sha}} bash
-        yum install -y --skip-broken devtoolset-3
+        yum info --skip-broken devtoolset-3

--- a/activate.sh
+++ b/activate.sh
@@ -3,44 +3,46 @@
 #
 # usage: activate.sh
 #
-# Fetch and activate vault/archive sclo repositories for current CentOS 7
-# version. Will also download required dependencies if missing:
+# Fetch and activate vault/archive sclo repositories for current/older CentOS 7
+# version which will have deprecated packages e.g. devtoolset-6.
 #
-# - tar, e.g. missing on CentOS 7.1
-# - yum-config-manager, e.g. missing on CentOS 7.1
+# Will also download/update required dependencies if missing:
 #
-# If any of the required dependencies are installed, curl will also be updated
-# so it can also pull/download from GitHub (more modern NSS).
+# - tar, i.e. for CentOS 7.1 where curl will be updated so it can
+#   also pull/download from GitHub (requires more modern NSS).
+# - yum-config-manager, for CentOS 7.1 and 7.2
+#
+# CentOS 7.7 and newer will actually activate 7.6's archive repository, which
+# is the latest CentOS 7 before older packages like devtoolset-6 got removed.
 #
 # ENVIRONMENT VARIABLES
 #
-#   GITHUB_SHA: Custom commit SHA to pull from GitHub,
-#               instead of the default master branch.
+#   SCL_TAR_SHA: Custom commit SHA to pull from GitHub,
+#                instead of the default master branch.
+#                Didn't use GITHUB_SHA directly here in-case this
+#                script was called from other project's CI.
 #
 set -eu -o pipefail
 
-cd /etc/yum.repos.d/
-SCL_TAR_SHA="${SCL_TAR_SHA:-master}"
-CENTOS_VAULT_SCL_TAR="https://github.com/wwfxuk/centos-vault-scl/archive/${SCL_TAR_SHA}.tar.gz"
 
+# Bash array's "${VAR[@]}" quoted expansion better for arguments to commands
 declare -a DEPS_NEEDED
-DEPS_NEEDED=(curl)
-command -v tar || DEPS_NEEDED+=("tar")
-command -v yum-config-manager || DEPS_NEEDED+=("yum-utils")
+command -v tar || DEPS_NEEDED+=("tar" "curl")  # missing/needs updating for 7.1
+command -v yum-config-manager || DEPS_NEEDED+=("yum-utils")  # missing for 7.1 and 7.2
 test -z "${DEPS_NEEDED}" || ( echo "Installing dependencies and updating curl..." && yum install -y "${DEPS_NEEDED[@]}")
 
+CENTOS_VAULT_SCL_TAR="https://github.com/wwfxuk/centos-vault-scl/archive/${SCL_TAR_SHA:-master}.tar.gz"
+cd /etc/yum.repos.d/
 echo "Extracting *.repo files from ${CENTOS_VAULT_SCL_TAR}"
 echo "into $(pwd)..."
 curl -sL "${CENTOS_VAULT_SCL_TAR}" | tar -v --strip-components=1 -xz '*.repo'
 ls -lah
 
-# e.g. 7.7.1908
+
+# Enable older archives if CentOS 7.7 and newer (test via build number)
+# e.g. CENTOS_RELEASE=7.7.1908, "${CENTOS_RELEASE##*.}" = 1908
 CENTOS_RELEASE=${CENTOS_RELEASE:-$(grep -oP '[\d\.]+' /etc/centos-release)}
-
-# Enable older archives for devtoolset-3, devtoolset-6, etc
-# if CentOS 7.7 and newer (test via build number)
 [ "${CENTOS_RELEASE##*.}" -le 1810 ] || CENTOS_RELEASE="7.6.1810"
-
 for SUFFIX in sclo rh
 do
     REPO="C${CENTOS_RELEASE}-centos-sclo-${SUFFIX}"
@@ -49,4 +51,4 @@ do
 done
 
 echo '========================================================================'
-echo 'You shoud be able to install packages like devtoolset-3 now!'
+echo 'You shoud also be able to install older packages like devtoolset-3 now!'

--- a/activate.sh
+++ b/activate.sh
@@ -37,9 +37,9 @@ test -t 1 && CURL_FLAGS+=("-#") || CURL_FLAGS+=("-sS")
 CURL_FLAGS+=("https://github.com/wwfxuk/centos-vault-scl/archive/${SCL_TAR_SHA:-master}.tar.gz")
 
 cd /etc/yum.repos.d/
-echo "Extracting *.repo files from ${CENTOS_VAULT_SCL_TAR}"
+echo "Extracting *.repo files from ${CURL_FLAGS[-1]}"
 echo "into $(pwd)..."
-curl "${CURL_FLAGS[@]}" "${CENTOS_VAULT_SCL_TAR}" | tar -v --strip-components=1 -xz '*.repo'
+curl "${CURL_FLAGS[@]}" | tar -v --strip-components=1 -xz '*.repo'
 ls -lah
 
 

--- a/activate.sh
+++ b/activate.sh
@@ -31,11 +31,15 @@ command -v tar || DEPS_NEEDED+=("tar" "curl")  # missing/needs updating for 7.1
 command -v yum-config-manager || DEPS_NEEDED+=("yum-utils")  # missing for 7.1 and 7.2
 test -z "${DEPS_NEEDED:-}" || ( echo "Installing dependencies and updating curl..." && yum install -y "${DEPS_NEEDED[@]}")
 
-CENTOS_VAULT_SCL_TAR="https://github.com/wwfxuk/centos-vault-scl/archive/${SCL_TAR_SHA:-master}.tar.gz"
+# Setup curl downloading flags
+CURL_FLAGS[0]="-L"
+test -t 1 && CURL_FLAGS+=("-#") || CURL_FLAGS+=("-sS")
+CURL_FLAGS+=("https://github.com/wwfxuk/centos-vault-scl/archive/${SCL_TAR_SHA:-master}.tar.gz")
+
 cd /etc/yum.repos.d/
 echo "Extracting *.repo files from ${CENTOS_VAULT_SCL_TAR}"
 echo "into $(pwd)..."
-curl -sL "${CENTOS_VAULT_SCL_TAR}" | tar -v --strip-components=1 -xz '*.repo'
+curl "${CURL_FLAGS[@]}" "${CENTOS_VAULT_SCL_TAR}" | tar -v --strip-components=1 -xz '*.repo'
 ls -lah
 
 

--- a/activate.sh
+++ b/activate.sh
@@ -29,7 +29,7 @@ set -eu -o pipefail
 declare -a DEPS_NEEDED
 command -v tar || DEPS_NEEDED+=("tar" "curl")  # missing/needs updating for 7.1
 command -v yum-config-manager || DEPS_NEEDED+=("yum-utils")  # missing for 7.1 and 7.2
-test -z "${DEPS_NEEDED}" || ( echo "Installing dependencies and updating curl..." && yum install -y "${DEPS_NEEDED[@]}")
+test -z "${DEPS_NEEDED:-}" || ( echo "Installing dependencies and updating curl..." && yum install -y "${DEPS_NEEDED[@]}")
 
 CENTOS_VAULT_SCL_TAR="https://github.com/wwfxuk/centos-vault-scl/archive/${SCL_TAR_SHA:-master}.tar.gz"
 cd /etc/yum.repos.d/


### PR DESCRIPTION
### Added

- Additional docs and comments for `activate.sh`
- `curl` status bar if `stdout` is a terminal

### Changed

- CI check and names to more closely match [J-M0:rpm](https://github.com/wwfxuk/centos-vault-scl/compare/v0.1.0..J-M0:rpm)
- Using bash arrays